### PR TITLE
Support showing / hiding based on active file editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can enable statusbar items based on the file in the active editor using the 
 
 For instance, the following would only display the "Test" button when a filename beginning with `test_` is the active editor:
 
-```js
+```json
 "label": "Test",
 "options": {
   "statusbar": {

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ You can change the name of the task displayed on the status bar with the followi
   }
 }
 ```
+
+You can enable statusbar items based on the file in the active editor using the `filePattern` attribute, causing the statusbar item to be hidden when the active file does not match the specified pattern. If the `filePattern` attribute is not provided, the statusbar item will not be hidden based on the active file. (Note that `filePattern` only applies to statusbar items that have not been otherwise effectively set as hidden through `tasks.json` or `settings.json`).
+
+For instance, the following would only display the "Test" button when a filename beginning with `test_` is the active editor:
+
+```js
+"label": "Test",
+"options": {
+  "statusbar": {
+    "filePattern" : "test_.*"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can change the name of the task displayed on the status bar with the followi
 }
 ```
 
-You can enable statusbar items based on the file in the active editor using the `filePattern` attribute, causing the statusbar item to be hidden when the active file does not match the specified pattern. If the `filePattern` attribute is not provided, the statusbar item will not be hidden based on the active file. (Note that `filePattern` only applies to statusbar items that have not been otherwise effectively set as hidden through `tasks.json` or `settings.json`).
+You can enable statusbar items based on the file in the active editor using the `filePattern` attribute, causing the statusbar item to be hidden when the active file does not match the specified pattern. If the `filePattern` attribute is not provided, the statusbar item will not be hidden based on the active file. Also, if it is provided but is invalid or causes an error during validation, the statusbar item will not be displayed. (Note that `filePattern` only applies to statusbar items that have not been otherwise effectively set as hidden through `tasks.json` or `settings.json`).
 
 For instance, the following would only display the "Test" button when a filename beginning with `test_` is the active editor:
 

--- a/extension.js
+++ b/extension.js
@@ -145,8 +145,8 @@ function syncStatusBarItemsWithActiveEditor() {
             continue;
         }
         statusBar.hide();
-        let currentFilePath = vscode.window.activeTextEditor.document.fileName;
-        if (!statusBar.filePattern || new RegExp(statusBar.filePattern).test(currentFilePath)) {
+        let currentFilePath = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.fileName;
+        if (!statusBar.filePattern || (currentFilePath && new RegExp(statusBar.filePattern).test(currentFilePath))) {
             statusBar.show();
         }
         else {

--- a/jshintrc.tasks.json
+++ b/jshintrc.tasks.json
@@ -33,6 +33,11 @@
                                         "type": "string",
                                         "default": "#FFF",
                                         "description": "Provided by extension:tasks.\nSet the foreground color of the statusbar.\nhttps://code.visualstudio.com/api/references/theme-color"
+                                    },
+                                    "filePattern": {
+                                        "type": "string",
+                                        "default": "file pattern of applicable files for statusbar",
+                                        "description": "Provided by extension:tasks.\nSet the active editor file pattern for which the statusbar is displayed.\nLeave blank to have always displayed."
                                     }
                                 }
                             }


### PR DESCRIPTION
This adds support to allow enabling statusbar items only when specific types of files are active in the editor. Not providing the `filePattern` attribute simply retains the previous behavior where the statusbar item is always displayed if not configured as hidden. (The new attribute only acts on statusbar items that are not effectively set as hidden through the combination of `tasks.json` or the `settings.json` global setting).

For example, the following would only display the "Test" button when the active editor is for a filename that begins with `_test`:

```js
"label": "Test",
"options": {
  "statusbar": {
    "filePattern" : "test_.*"
  }
}
```