### PR TITLE
Add option to manually specify task order

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -78,11 +78,11 @@ function getStatusBar(task, global, key) {
 }
 
 function computeTaskExecutionId(values) {
-	let id = '';
-	for (let i = 0; i < values.length; i++) {
-		id += values[i].replace(/,/g, ',,') + ',';
-	}
-	return id;
+    let id = '';
+    for (let i = 0; i < values.length; i++) {
+        id += values[i].replace(/,/g, ',,') + ',';
+    }
+    return id;
 }
 
 function computeIdForNpm(task, config, name) {
@@ -90,18 +90,18 @@ function computeIdForNpm(task, config, name) {
     if (typeof script != "string") {
         script = "";
     }
-    return name+",vscode.npm.script,"+script+",type,npm,";
+    return name + ",vscode.npm.script," + script + ",type,npm,";
 }
 
 function computeId(task, config) {
-    const name    = "label" in task ? task.label : task.taskName;
-    const type    = getValue(task, config, "type");
+    const name = "label" in task ? task.label : task.taskName;
+    const type = getValue(task, config, "type");
     if (type == "npm") {
         return computeIdForNpm(task, config, name);
     }
     const props = [];
     const command = getValue(task, config, "command");
-    const args    = getValue(task, config, "args");
+    const args = getValue(task, config, "args");
     if (typeof name == "string") {
         props.push(name);
     }
@@ -148,7 +148,7 @@ function getTaskId(task) {
 
 function convertColor(color) {
     if (typeof color == "string") {
-        if (color.slice(0,1) === "#") {
+        if (color.slice(0, 1) === "#") {
             return info.color;
         }
         else {
@@ -199,15 +199,18 @@ function loadTasks(context) {
                 tooltip: getStatusBar(task, config, "tooltip"),
                 color: getStatusBar(task, config, "color"),
                 filePattern: getStatusBar(task, config, "filePattern"),
+                position: getStatusBar(task, config, "position")
             }
         }
     }
 
     vscode.tasks.fetchTasks().then((tasks) => {
-        for (const task of tasks) {
-            if (task.source != "Workspace") {
-                continue;
-            }
+        let sortedTasks = tasks.filter(task => task.source == "Workspace").sort((task1, task2) => {
+            let a = statusBarInfo[task1.name + ',' + getTaskId(task1)].position || 0
+            let b = statusBarInfo[task2.name + ',' + getTaskId(task2)].position || 0
+            return a - b
+        })
+        for (const task of sortedTasks) {
             let taskId = task.name + ',' + getTaskId(task);
             let info = statusBarInfo[taskId] || {}
             if (info.hide) {
@@ -224,7 +227,7 @@ function loadTasks(context) {
             context.subscriptions.push(statusBar);
             if (!(command in commandMap)) {
                 context.subscriptions.push(vscode.commands.registerCommand(command, () => {
-                    vscode.tasks.executeTask(commandMap[command]).catch((e)=>{
+                    vscode.tasks.executeTask(commandMap[command]).catch((e) => {
                         console.error(e)
                     });
                 }));

--- a/jshintrc.tasks.json
+++ b/jshintrc.tasks.json
@@ -38,6 +38,11 @@
                                         "type": "string",
                                         "default": "file pattern of applicable files for statusbar",
                                         "description": "Provided by extension:tasks.\nSet the active editor file pattern for which the statusbar is displayed.\nLeave blank to have always displayed."
+                                    },
+                                    "position": {
+                                        "type": "integer",
+                                        "default": 0,
+                                        "description": "Provided by extension:tasks.\nUse this to manually set the order of tasks in the statusbar."
                                     }
                                 }
                             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tasks",
     "displayName": "Tasks",
     "description": "Load VSCode Tasks into Status Bar.",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "publisher": "actboy168",
     "repository": {
         "type": "git",
@@ -27,12 +27,10 @@
     ],
     "main": "./extension.js",
     "contributes": {
-        "jsonValidation": [
-            {
-                "fileMatch": "tasks.json",
-                "url": "./jshintrc.tasks.json"
-            }
-        ],
+        "jsonValidation": [{
+            "fileMatch": "tasks.json",
+            "url": "./jshintrc.tasks.json"
+        }],
         "configuration": {
             "properties": {
                 "tasks.default.statusbar.hide": {


### PR DESCRIPTION
I found that sometimes the order of the tasks shown can be inconsistent (at least in newer versions of VSCode), breaking the logical order of large, multi-step workflows.

<img width="209" alt="image" src="https://user-images.githubusercontent.com/3750464/75506336-ad4ce980-59ab-11ea-96c8-1c1c8ae2eecb.png">

<small>I wanted this to be <key>Build</key>, <key>Prebuild</key>, <key>Deploy</key></small>

This change is quite simple: it adds a `position` field to the status bar options. When the extension loads the tasks, it sorts them according to the `position` value, which defaults to `0`.

This allowed me to fix the mess

```javascript
{
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Build",
      // ...
      "options": {
        "statusbar": {
          "label": "$(tools) Build",
          "position": 0
        }
      }
    },
    {
      "label": "Rebuild",
      // ...
      "options": {
        "statusbar": {
          "label": "$(sync) Rebuild",
          "position": 1
        }
      }
    },
    {
      "label": "Deploy",
      // ...
      "options": {
        "statusbar": {
          "label": "$(rocket) Deploy",
          "position": 2
        }
      }
    }
  ]
}
```

Which yields the following result:

<img width="206" alt="image" src="https://user-images.githubusercontent.com/3750464/75506532-4aa81d80-59ac-11ea-9249-55da9d69d4eb.png">

Much better! 🎉

---

PS: I also bumped the version number to `0.3.7`.