### PR TITLE
add a function: show visual representation for running tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
                 "tasks.statusbar.select.color": {
                     "type": "string",
                     "default": ""
+                },
+                "tasks.statusbar.default.indicator": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show visual representation for running tasks (preview)"
                 }
             }
         }


### PR DESCRIPTION
Considering that some users want the status bar button to have a special display when running tasks to indicate that the corresponding task is running, I have attempted to add this feature. About two years ago, I had a similar plan, but due to some of your concerns, I gave up. Now I have re examined the feasibility of this feature and reviewed the official documentation. I am not sure if this will affect other features of the plugin. I hope you can provide your feedback. Since my last merge request, you have refactored most of the code, and there are some parts that I cannot fully understand. Therefore, I cannot be 100% certain that the code for this price increase will adapt to all scenarios. If possible, perhaps improvements can be made in subsequent work.

About this pull request:
1. Bind the task with the bar to find the corresponding bar through the task definition
2. Listen for task start and stop events, find the bar through the binding relationship above, and modify its text to display a dynamic icon
3. Provide an optional configuration for this function to register or unregister the dispose when the configuration is updated

effect:
![image](https://github.com/actboy168/vscode-tasks/assets/39125296/1dbe96bf-cbad-4bb6-8b75-bafa471242ad)
