### PR TITLE
Fixing 1.79.0-insiders only shows single task - even when there are multiple #44 = by adding index into identifier

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -362,7 +362,7 @@ function createSelectStatusBar() {
 function syncStatusBar(memoryStatusBarArray) {
     const diff = memoryStatusBarArray.length - statusBarArray.length;
     for (let i = 0; i < diff; ++i) {
-        let statusBar = vscode.window.createStatusBarItem("actboy168.tasks", vscode.StatusBarAlignment.Left, 50);
+        let statusBar = vscode.window.createStatusBarItem(`actboy168.tasks.task-${i}`, vscode.StatusBarAlignment.Left, 50);
         statusBar.name = "Tasks";
         statusBarArray.push(statusBar);
     }


### PR DESCRIPTION
I added the index of the statusbar entry to the identifier - hope this is a good fix for you @actboy168 