### PR TITLE
Add grouping for tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
             "runtimeExecutable": "${execPath}",
             "sourceMaps": false,
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
+                "--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test-workspace",
             ]
         }
     ]

--- a/extension.js
+++ b/extension.js
@@ -1016,14 +1016,15 @@ function showMasterTasksPanel(masterTree) {
                 const taskCount = group.tasks.length + countNestedTasks(group.subgroups);
                 html += generateGroupButton(groupName, group.fullPath, taskCount, level);
 
+                // Recursive subgroups
+                html += generateMasterTreeHTML(group.subgroups, level + 1);
+
                 // Direct tasks in this group
                 for (const task of group.tasks) {
                     const taskIndex = allTasks.indexOf(task);
                     html += generateTaskButton(task, taskIndex, level + 1);
                 }
 
-                // Recursive subgroups
-                html += generateMasterTreeHTML(group.subgroups, level + 1);
                 html += '</div></div>';
             }
         }
@@ -1185,6 +1186,22 @@ function showHierarchicalGroupTasks(groupTree) {
     function generateTreeHTML(group, level = 0) {
         let html = '';
 
+				// Add subgroups
+				for (const [subgroupName, subgroup] of group.subgroups) {
+						html += `
+								<div class="subgroup" style="margin-left: ${level * 20}px;">
+										<button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')"
+														title="Expand/Collapse ${subgroupName}">
+												<span class="expand-icon" id="icon-${subgroupName}-${level}">▶</span>
+												<span class="subgroup-name">${subgroupName}/</span>
+										</button>
+										<div class="subgroup-content" id="content-${subgroupName}-${level}" style="display: none;">
+												${generateTreeHTML(subgroup, level + 1)}
+										</div>
+								</div>
+						`;
+				}
+
         // Add direct tasks at this level
         const directTasks = group.tasks.filter(task => {
             const hierarchy = parseGroupHierarchy(task.group);
@@ -1196,21 +1213,6 @@ function showHierarchicalGroupTasks(groupTree) {
             html += generateTaskButton(task, taskIndex, level);
         }
 
-        // Add subgroups
-        for (const [subgroupName, subgroup] of group.subgroups) {
-            html += `
-                <div class="subgroup" style="margin-left: ${level * 20}px;">
-                    <button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')"
-                            title="Expand/Collapse ${subgroupName}">
-                        <span class="expand-icon" id="icon-${subgroupName}-${level}">▶</span>
-                        <span class="subgroup-name">${subgroupName}/</span>
-                    </button>
-                    <div class="subgroup-content" id="content-${subgroupName}-${level}" style="display: none;">
-                        ${generateTreeHTML(subgroup, level + 1)}
-                    </div>
-                </div>
-            `;
-        }
 
         return html;
     }

--- a/extension.js
+++ b/extension.js
@@ -482,43 +482,54 @@ function buildGroupTree(memoryStatusBarArray) {
     }
 
     const result = [];
+    const addedGroups = new Set();
 
-    // Add ungrouped tasks first
-    result.push(...ungroupedTasks);
-
-    // Process each root group
-    for (const [rootName, rootGroup] of tree) {
-        // Check if group has only one task
-        if (rootGroup.tasks.length === 1) {
-            // Show the individual task instead of a group button
-            const singleTask = rootGroup.tasks[0];
-            result.push({
-                text: singleTask.text,
-                tooltip: singleTask.tooltip,
-                color: singleTask.color,
-                backgroundColor: singleTask.backgroundColor,
-                filePattern: singleTask.filePattern,
-                isGroup: false, // Mark as individual task
-                command: singleTask.command // Use the task's command directly
-            });
+    // Process in original order
+    for (const task of memoryStatusBarArray) {
+        if (!task.group) {
+            // Ungrouped task
+            result.push(task);
         } else {
-            // Create a group button for multiple tasks
-            result.push({
-                text: rootName,
-                tooltip: convertTooltip(`Group: ${rootName} (${rootGroup.tasks.length} tasks)`),
-                color: rootGroup.tasks[0]?.color,
-                backgroundColor: rootGroup.tasks[0]?.backgroundColor,
-                filePattern: rootGroup.tasks[0]?.filePattern,
-                isGroup: true,
-                isHierarchical: true,
-                groupPath: rootName,
-                groupTree: rootGroup,
-                groupTasks: rootGroup.tasks,
-                command: {
-                    command: ShowGroupTasksCommand,
-                    arguments: [rootGroup.tasks, rootGroup]
+            const hierarchy = parseGroupHierarchy(task.group);
+            const rootGroup = hierarchy?.parts[0];
+
+            if (rootGroup && !addedGroups.has(rootGroup)) {
+                addedGroups.add(rootGroup);
+                const groupData = tree.get(rootGroup);
+
+                if (groupData.tasks.length === 1) {
+                    // Single task group
+										// Show the individual task instead of a group button
+                    const singleTask = groupData.tasks[0];
+                    result.push({
+                        text: singleTask.text,
+                        tooltip: singleTask.tooltip,
+                        color: singleTask.color,
+                        backgroundColor: singleTask.backgroundColor,
+                        filePattern: singleTask.filePattern,
+                        isGroup: false, // Mark as individual task
+                        command: singleTask.command // Use the task's command directly
+                    });
+                } else {
+                    // Multi-task group
+                    result.push({
+                        text: rootGroup,
+                        tooltip: convertTooltip(`Group: ${rootGroup} (${groupData.tasks.length} tasks)`),
+                        color: groupData.tasks[0]?.color,
+                        backgroundColor: groupData.tasks[0]?.backgroundColor,
+                        filePattern: groupData.tasks[0]?.filePattern,
+                        isGroup: true,
+                        isHierarchical: true,
+                        groupPath: rootGroup,
+                        groupTree: groupData,
+                        groupTasks: groupData.tasks,
+                        command: {
+                            command: ShowGroupTasksCommand,
+                            arguments: [groupData.tasks, groupData]
+                        }
+                    });
                 }
-            });
+            }
         }
     }
 

--- a/extension.js
+++ b/extension.js
@@ -699,10 +699,8 @@ function loadTasks() {
             openUpdateStatusBar();
         }
         else {
-            // Even if no tasks, show the master tasks button
-            const masterOnly = [createMasterTasksStatusBar()];
-            syncStatusBar(masterOnly);
-            openUpdateStatusBar();
+            cleanStatusBar();
+            closeUpdateStatusBar();
         }
     });
 }

--- a/extension.js
+++ b/extension.js
@@ -1504,40 +1504,6 @@ const panelCSS = `
     .ungrouped-section {
       margin-top: 16px;
     }
-
-    // .task-description {
-    //     font-size: 0.9em;
-    //     color: var(--vscode-descriptionForeground);
-    //     margin-top: 2px;
-    // }
-    // .task-button:hover {
-    //     background: var(--vscode-list-hoverBackground);
-    // }
-    // .subgroup-header {
-    //     display: block;
-    //     width: calc(100% - 20px);
-    //     padding: 4px 12px;
-    //     margin: 2px 0;
-    //     background: transparent;
-    //     border: none;
-    //     color: var(--vscode-foreground);
-    //     cursor: pointer;
-    //     text-align: left;
-    //     border-radius: 2px;
-    //     font-weight: 500;
-    // }
-    // .subgroup-header:hover {
-    //     background: var(--vscode-list-hoverBackground);
-    // }
-    // .subgroup-name {
-    //     color: var(--vscode-symbolIcon-folderForeground);
-    // }
-    // .subgroup-content {
-    //     overflow: hidden;
-    //     transition: all 0.2s ease;
-    // }
-
-
     .subgroup-header {
         display: block;
         width: calc(100% - 20px);

--- a/extension.js
+++ b/extension.js
@@ -88,7 +88,7 @@ function cleanStatusBar() {
 function deactivate() {
     closeUpdateStatusBar();
     cleanStatusBar();
-    
+
     // Clean up all active panels
     for (const [panelKey, panel] of activePanels) {
         try {
@@ -100,7 +100,7 @@ function deactivate() {
         }
     }
     activePanels.clear();
-    
+
     if (outputChannel !== undefined) {
         outputChannel.dispose();
     }
@@ -238,14 +238,14 @@ function parseGroupHierarchy(groupString) {
     if (!groupString || typeof groupString !== 'string') {
         return null;
     }
-    
+
     // Split by forward slash and clean up each part
     const parts = groupString.split('/').map(part => part.trim()).filter(part => part.length > 0);
-    
+
     if (parts.length === 0) {
         return null;
     }
-    
+
     return {
         fullPath: groupString,
         parts: parts,
@@ -443,7 +443,7 @@ function createSelectStatusBar() {
 function buildGroupTree(memoryStatusBarArray) {
     const groupedTasks = [];
     const ungroupedTasks = [];
-    
+
     // Separate grouped and ungrouped tasks
     for (const statusBarItem of memoryStatusBarArray) {
         if (statusBarItem.group) {
@@ -452,14 +452,14 @@ function buildGroupTree(memoryStatusBarArray) {
             ungroupedTasks.push(statusBarItem);
         }
     }
-    
+
     if (groupedTasks.length === 0) {
         return ungroupedTasks;
     }
-    
+
     // Build tree structure
     const tree = new Map();
-    
+
     // First pass: collect all tasks by their root groups
     for (const task of groupedTasks) {
         const hierarchy = parseGroupHierarchy(task.group);
@@ -475,17 +475,17 @@ function buildGroupTree(memoryStatusBarArray) {
             tree.get(rootGroup).tasks.push(task);
         }
     }
-    
+
     // Build the hierarchical tree for each root group
     for (const [rootName, rootGroup] of tree) {
         buildSubgroupTree(rootGroup, rootGroup.tasks);
     }
-    
+
     const result = [];
-    
+
     // Add ungrouped tasks first
     result.push(...ungroupedTasks);
-    
+
     // Process each root group
     for (const [rootName, rootGroup] of tree) {
         // Check if group has only one task
@@ -521,7 +521,7 @@ function buildGroupTree(memoryStatusBarArray) {
             });
         }
     }
-    
+
     return result;
 }
 
@@ -529,7 +529,7 @@ function buildSubgroupTree(parentGroup, tasks) {
     // Group tasks by their next level path segment relative to parent
     const subgroupMap = new Map();
     const directTasks = [];
-    
+
     for (const task of tasks) {
         const hierarchy = parseGroupHierarchy(task.group);
         if (hierarchy && hierarchy.parts.length > 1) {
@@ -548,7 +548,7 @@ function buildSubgroupTree(parentGroup, tasks) {
             directTasks.push(task);
         }
     }
-    
+
     // Build subgroup tree recursively
     for (const [subgroupName, subgroupTasks] of subgroupMap) {
         const fullSubgroupPath = parentGroup.name === subgroupName ? subgroupName : `${parentGroup.name}/${subgroupName}`;
@@ -557,9 +557,9 @@ function buildSubgroupTree(parentGroup, tasks) {
             tasks: subgroupTasks,
             subgroups: new Map()
         };
-        
+
         parentGroup.subgroups.set(subgroupName, subgroup);
-        
+
         // Recursively build deeper levels
         buildSubgroupTree(subgroup, subgroupTasks);
     }
@@ -631,7 +631,7 @@ function matchTasksInScope(memoryStatusBarArray, tasks, runningTasks, config) {
         const backgroundColor = getAttribute(taskObject, taskInfo, "backgroundColor", isRunning);
         const filePattern = getAttribute(taskObject, taskInfo, "filePattern");
         const group = getTaskGroup(taskInfo);
-        
+
         memoryStatusBarArray.push({
             text: label,
             tooltip: convertTooltip(detail),
@@ -746,7 +746,7 @@ function refreshTask(task) {
         }
         if (statusBar.isGroup) {
             // Check if task is in group
-            return statusBar.groupTasks && statusBar.groupTasks.some(groupTask => 
+            return statusBar.groupTasks && statusBar.groupTasks.some(groupTask =>
                 groupTask.command.arguments[0]._id === task._id
             );
         }
@@ -756,7 +756,7 @@ function refreshTask(task) {
         const statusBar = memoryStatusBarArray[0];
         if (found.isGroup && found.groupTasks) {
             // Update task within group
-            const taskInGroup = found.groupTasks.find(groupTask => 
+            const taskInGroup = found.groupTasks.find(groupTask =>
                 groupTask.command.arguments[0]._id === task._id
             );
             if (taskInGroup) {
@@ -785,10 +785,10 @@ function showAllTasks() {
     vscode.tasks.fetchTasks().then((allTasks) => {
         const workspaceTasks = allTasks.filter(task => task.source === "Workspace");
         const allTaskItems = matchAllTasks(workspaceTasks);
-        
+
         // Build complete hierarchical tree
         const masterTree = buildMasterTaskTree(allTaskItems);
-        
+
         // Show in webview panel
         showMasterTasksPanel(masterTree);
     });
@@ -800,7 +800,7 @@ function buildMasterTaskTree(allTaskItems) {
         groups: new Map(),
         ungroupedTasks: []
     };
-    
+
     // Separate grouped and ungrouped tasks
     for (const task of allTaskItems) {
         if (task.group) {
@@ -812,19 +812,19 @@ function buildMasterTaskTree(allTaskItems) {
             tree.ungroupedTasks.push(task);
         }
     }
-    
+
     return tree;
 }
 
 function addTaskToTree(tree, hierarchy, task) {
     let currentLevel = tree.groups;
     let currentPath = "";
-    
+
     // Navigate/create the tree structure
     for (let i = 0; i < hierarchy.parts.length; i++) {
         const part = hierarchy.parts[i];
         currentPath = currentPath ? `${currentPath}/${part}` : part;
-        
+
         if (!currentLevel.has(part)) {
             currentLevel.set(part, {
                 name: part,
@@ -833,14 +833,14 @@ function addTaskToTree(tree, hierarchy, task) {
                 subgroups: new Map()
             });
         }
-        
+
         const group = currentLevel.get(part);
-        
+
         // If this is the final level, add the task
         if (i === hierarchy.parts.length - 1) {
             group.tasks.push(task);
         }
-        
+
         // Move to next level
         currentLevel = group.subgroups;
     }
@@ -858,16 +858,16 @@ function createOrFocusPanel(panelKey, title, createPanelFn) {
             activePanels.delete(panelKey);
         }
     }
-    
+
     // Create new panel
     const panel = createPanelFn();
     activePanels.set(panelKey, panel);
-    
+
     // Set up common disposal handling
     panel.onDidDispose(() => {
         activePanels.delete(panelKey);
     });
-    
+
     return panel;
 }
 
@@ -877,7 +877,7 @@ function createWebviewPanel(id, title, options = {}) {
         retainContextWhenHidden: true,
         localResourceRoots: []
     };
-    
+
     return vscode.window.createWebviewPanel(
         id,
         title,
@@ -896,7 +896,7 @@ function setupPanelMessageHandling(panel, panelKey, messageHandlers) {
             panel.dispose();
             return;
         }
-        
+
         const handler = messageHandlers[message.command];
         if (handler) {
             handler(message);
@@ -916,9 +916,9 @@ function generateTaskButton(task, index, indentLevel = 0) {
     const label = task.text.replace(/\$\([^)]+\)\s*/, '');
     const tooltip = task.tooltip ? task.tooltip.value || '' : '';
     const indent = indentLevel * 20;
-    
+
     return `
-        <button class="task-button" onclick="executeTask(${index})" 
+        <button class="task-button" onclick="executeTask(${index})"
                 title="${tooltip}" style="margin-left: ${indent}px;">
             <span class="task-icon">•</span>
             <span class="task-label">${label}</span>
@@ -929,10 +929,10 @@ function generateTaskButton(task, index, indentLevel = 0) {
 function generateGroupButton(groupName, groupPath, taskCount, level = 0) {
     const indent = level * 20;
     const groupId = `group-${groupPath.replace(/[^a-zA-Z0-9]/g, '-')}-${level}`;
-    
+
     return `
         <div class="group-container" style="margin-left: ${indent}px;">
-            <button class="group-header" onclick="toggleGroup('${groupId}')" 
+            <button class="group-header" onclick="toggleGroup('${groupId}')"
                     title="${groupPath}">
                 <span class="expand-icon" id="icon-${groupId}">▶</span>
                 <span class="group-name">${groupName}/</span>
@@ -947,7 +947,7 @@ function getCommonJavaScript(dataArray, dataVariableName = 'allTasks') {
     return `
         const vscode = acquireVsCodeApi();
         const ${dataVariableName} = ${JSON.stringify(dataArray)};
-        
+
         function executeTask(index) {
             if (index >= 0 && index < ${dataVariableName}.length) {
                 vscode.postMessage({
@@ -956,11 +956,11 @@ function getCommonJavaScript(dataArray, dataVariableName = 'allTasks') {
                 });
             }
         }
-        
+
         function toggleGroup(id) {
             const content = document.getElementById('content-' + id);
             const icon = document.getElementById('icon-' + id);
-            
+
             if (content && icon) {
                 if (content.style.display === 'none') {
                     content.style.display = 'block';
@@ -971,11 +971,11 @@ function getCommonJavaScript(dataArray, dataVariableName = 'allTasks') {
                 }
             }
         }
-        
+
         window.addEventListener('load', () => {
             document.body.focus();
         });
-        
+
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 vscode.postMessage({ command: 'close' });
@@ -986,11 +986,11 @@ function getCommonJavaScript(dataArray, dataVariableName = 'allTasks') {
 
 function showMasterTasksPanel(masterTree) {
     const panelKey = 'masterTasksPanel';
-    
-    const panel = createOrFocusPanel(panelKey, 'All Tasks', () => 
+
+    const panel = createOrFocusPanel(panelKey, 'All Tasks', () =>
         createWebviewPanel('masterTasksPanel', 'All Tasks')
     );
-    
+
     if (!panel) return; // Panel already exists and was focused
 
     // Collect all tasks for execution mapping
@@ -1007,30 +1007,30 @@ function showMasterTasksPanel(masterTree) {
     // Generate tree HTML
     function generateMasterTreeHTML(groups, level = 0) {
         let html = '';
-        
+
         for (const [groupName, group] of groups) {
             const hasSubgroups = group.subgroups.size > 0;
             const hasDirectTasks = group.tasks.length > 0;
-            
+
             if (hasSubgroups || hasDirectTasks) {
                 const taskCount = group.tasks.length + countNestedTasks(group.subgroups);
                 html += generateGroupButton(groupName, group.fullPath, taskCount, level);
-                
+
                 // Direct tasks in this group
                 for (const task of group.tasks) {
                     const taskIndex = allTasks.indexOf(task);
                     html += generateTaskButton(task, taskIndex, level + 1);
                 }
-                
+
                 // Recursive subgroups
                 html += generateMasterTreeHTML(group.subgroups, level + 1);
                 html += '</div></div>';
             }
         }
-        
+
         return html;
     }
-    
+
     function countNestedTasks(groups) {
         let count = 0;
         for (const [_, group] of groups) {
@@ -1063,10 +1063,10 @@ function showMasterTasksPanel(masterTree) {
             <div class="header">All Tasks</div>
             ${generateMasterTreeHTML(masterTree.groups)}
             ${ungroupedHTML}
-            
+
             <script>
                 ${getCommonJavaScript(allTasks)}
-                
+
                 // Auto-expand first level on load
                 window.addEventListener('load', () => {
                     const firstLevelGroups = document.querySelectorAll('[id^="content-group-"][id$="-0"]');
@@ -1095,11 +1095,11 @@ function showMasterTasksPanel(masterTree) {
 
 function showSelectTasks(items) {
     const panelKey = 'taskSelectDropdown';
-    
-    const panel = createOrFocusPanel(panelKey, 'Select Tasks', () => 
+
+    const panel = createOrFocusPanel(panelKey, 'Select Tasks', () =>
         createWebviewPanel('taskSelectDropdown', 'Select Tasks')
     );
-    
+
     if (!panel) return;
 
     // Generate HTML for all tasks including groups
@@ -1107,10 +1107,10 @@ function showSelectTasks(items) {
         const label = item.text.replace(/\$\([^)]+\)\s*/, '');
         const tooltip = item.tooltip ? item.tooltip.value || '' : '';
         const isGroup = item.isGroup;
-        
+
         return `
-            <button class="task-button ${isGroup ? 'group-button' : ''}" 
-                    onclick="${isGroup ? `showGroup(${index})` : `executeTask(${index})`}" 
+            <button class="task-button ${isGroup ? 'group-button' : ''}"
+                    onclick="${isGroup ? `showGroup(${index})` : `executeTask(${index})`}"
                     title="${tooltip}">
                 <span class="task-label">${label}${isGroup ? ' ▼' : ''}</span>
                 ${tooltip ? `<span class="task-description">${tooltip}</span>` : ''}
@@ -1131,7 +1131,7 @@ function showSelectTasks(items) {
             ${taskButtons}
             <script>
                 ${getCommonJavaScript(items)}
-                
+
                 function showGroup(index) {
                     vscode.postMessage({
                         command: 'showGroup',
@@ -1174,33 +1174,33 @@ function showSelectTasks(items) {
 
 function showHierarchicalGroupTasks(groupTree) {
     const panelKey = `hierarchicalTaskGroup-${groupTree.name.replace(/[^a-zA-Z0-9]/g, '-')}`;
-    
-    const panel = createOrFocusPanel(panelKey, groupTree.name, () => 
+
+    const panel = createOrFocusPanel(panelKey, groupTree.name, () =>
         createWebviewPanel('hierarchicalTaskGroup', groupTree.name)
     );
-    
+
     if (!panel) return;
 
     // Generate HTML for hierarchical view
     function generateTreeHTML(group, level = 0) {
         let html = '';
-        
+
         // Add direct tasks at this level
         const directTasks = group.tasks.filter(task => {
             const hierarchy = parseGroupHierarchy(task.group);
             return hierarchy && hierarchy.parts.length === level + 1;
         });
-        
+
         for (const task of directTasks) {
             const taskIndex = group.tasks.indexOf(task);
             html += generateTaskButton(task, taskIndex, level);
         }
-        
+
         // Add subgroups
         for (const [subgroupName, subgroup] of group.subgroups) {
             html += `
                 <div class="subgroup" style="margin-left: ${level * 20}px;">
-                    <button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')" 
+                    <button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')"
                             title="Expand/Collapse ${subgroupName}">
                         <span class="expand-icon" id="icon-${subgroupName}-${level}">▶</span>
                         <span class="subgroup-name">${subgroupName}/</span>
@@ -1211,7 +1211,7 @@ function showHierarchicalGroupTasks(groupTree) {
                 </div>
             `;
         }
-        
+
         return html;
     }
 
@@ -1226,14 +1226,14 @@ function showHierarchicalGroupTasks(groupTree) {
         <body>
             <div class="header">${groupTree.name}:</div>
             ${generateTreeHTML(groupTree)}
-            
+
             <script>
                 ${getCommonJavaScript(groupTree.tasks, 'groupTasks')}
-                
+
                 function toggleSubgroup(id) {
                     const content = document.getElementById('content-' + id);
                     const icon = document.getElementById('icon-' + id);
-                    
+
                     if (content.style.display === 'none') {
                         content.style.display = 'block';
                         icon.classList.add('expanded');
@@ -1264,11 +1264,11 @@ function showGroupTasks(groupTasks, groupName = 'Tasks') {
 
     // const panelKey = `taskGroupDropdown-${groupName}`;
     const panelKey = `taskGroupDropdown-${groupName.replace(/[^a-zA-Z0-9]/g, '-')}`;
-    
-    const panel = createOrFocusPanel(panelKey, groupName, () => 
+
+    const panel = createOrFocusPanel(panelKey, groupName, () =>
         createWebviewPanel('taskGroupDropdown', groupName)
     );
-    
+
     if (!panel) return;
 
     // Generate HTML for the dropdown
@@ -1385,14 +1385,14 @@ function activate(context) {
                 runTask(groupTasks[0].command.arguments[0]);
                 return;
             }
-            
+
             // Extract group name from the first task in the group
             let groupName = 'Tasks';
             if (groupTasks.length > 0 && groupTasks[0].group) {
                 const groupPath = groupTasks[0].group;
                 groupName = getGroupDisplayName(groupPath);
             }
-            
+
             // If we have a tree structure, show hierarchical view
             if (groupTree) {
                 showHierarchicalGroupTasks(groupTree);

--- a/extension.js
+++ b/extension.js
@@ -1193,35 +1193,41 @@ function showHierarchicalGroupTasks(groupTree) {
 
     if (!panel) return;
 
-    // Generate HTML for hierarchical view
+    // === NEW: one flat array that mirrors on-screen button order ===
+    const flatTasks = [];
+
+    // Generate HTML and populate flatTasks in the exact render order
     function generateTreeHTML(group, level = 0) {
         let html = '';
 
-				// Add subgroups
-				for (const [subgroupName, subgroup] of group.subgroups) {
-						html += `
-								<div class="subgroup" style="margin-left: ${level * 20}px;">
-										<button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')"
-														title="Expand/Collapse ${subgroupName}">
-												<span class="expand-icon" id="icon-${subgroupName}-${level}">▶</span>
-												<span class="subgroup-name">${subgroupName}/</span>
-										</button>
-										<div class="subgroup-content" id="content-${subgroupName}-${level}" style="display: none;">
-												${generateTreeHTML(subgroup, level + 1)}
-										</div>
-								</div>
-						`;
-				}
+        // Subgroups first (keeps your current visual order)
+        for (const [_, subgroup] of group.subgroups) {
+            const safeId = `${subgroup.name.replace(/[^a-zA-Z0-9]/g, '-')}-${level}`;
+            html += `
+                <div class="subgroup" style="margin-left: ${level * 20}px;">
+                    <button class="subgroup-header" onclick="toggleSubgroup('${safeId}')"
+                            title="Expand/Collapse ${subgroup.name}">
+                        <span class="expand-icon" id="icon-${safeId}">▶</span>
+                        <span class="subgroup-name">${subgroup.name.split('/').slice(-1)[0]}/</span>
+                    </button>
+                    <div class="subgroup-content" id="content-${safeId}" style="display: none;">
+                        ${generateTreeHTML(subgroup, level + 1)}
+                    </div>
+                </div>
+            `;
+        }
 
-        // Add direct tasks at this level
-        const directTasks = group.tasks.filter(task => {
-            const hierarchy = parseGroupHierarchy(task.group);
-            return hierarchy && hierarchy.parts.length === level + 1;
+        // Direct tasks at this level
+        // (Your build tree stores all tasks under a node; we filter "direct" ones by depth)
+        const parentDepth = group.name.split('/').length;
+        const directTasks = group.tasks.filter(t => {
+            const h = parseGroupHierarchy(t.group);
+            return h && h.parts.length === parentDepth;
         });
 
         for (const task of directTasks) {
-            const taskIndex = group.tasks.indexOf(task);
-            html += generateTaskButton(task, taskIndex, level);
+            const idx = flatTasks.push(task) - 1; // index in the global flat list
+            html += generateTaskButton(task, idx, level);
         }
 
 
@@ -1241,7 +1247,7 @@ function showHierarchicalGroupTasks(groupTree) {
             ${generateTreeHTML(groupTree)}
 
             <script>
-                ${getCommonJavaScript(groupTree.tasks, 'groupTasks')}
+                ${getCommonJavaScript(flatTasks, 'groupTasks')}
 
                 function toggleSubgroup(id) {
                     const content = document.getElementById('content-' + id);
@@ -1260,11 +1266,12 @@ function showHierarchicalGroupTasks(groupTree) {
         </html>
     `;
 
+    // === NEW: resolve clicks against the same flatTasks array ===
     setupPanelMessageHandling(panel, panelKey, {
         executeTask: (message) => {
-            const taskIndex = message.taskIndex;
-            if (taskIndex >= 0 && taskIndex < groupTree.tasks.length) {
-                const task = groupTree.tasks[taskIndex].command.arguments[0];
+            const i = message.taskIndex;
+            if (i >= 0 && i < flatTasks.length) {
+                const task = flatTasks[i].command.arguments[0];
                 runTask(task);
             }
         }
@@ -1272,6 +1279,7 @@ function showHierarchicalGroupTasks(groupTree) {
 
     autoFocusPanel(panel);
 }
+
 
 function showGroupTasks(groupTasks, groupName = 'Tasks') {
 

--- a/extension.js
+++ b/extension.js
@@ -1,12 +1,15 @@
 const vscode = require('vscode');
 const os = require('os');
 
+var activePanels = new Map(); // Track active panels: key = panelKey, value = panel
 var statusBarArray = [];
 var selectList = [];
 var eventChangeActiveTextEditor;
 var outputChannel;
 const RunTaskCommand = "actboy168.run-task"
 const SelectTaskCommand = "actboy168.select-task"
+const ShowGroupTasksCommand = "actboy168.show-group-tasks"
+const ShowAllTasksCommand = "actboy168.show-all-tasks"
 
 //const VSCodeVersion = (function() {
 //    const res = vscode.version.split(".");
@@ -45,7 +48,7 @@ function updateStatusBar() {
                 selectList.push({
                     label: statusBar.text,
                     description: statusBar.tooltip ? statusBar.tooltip.value : undefined,
-                    task: statusBar.command.arguments[0]
+                    task: statusBar.isGroup ? statusBar.groupTasks : statusBar.command.arguments[0]
                 });
             }
             else {
@@ -85,6 +88,19 @@ function cleanStatusBar() {
 function deactivate() {
     closeUpdateStatusBar();
     cleanStatusBar();
+    
+    // Clean up all active panels
+    for (const [panelKey, panel] of activePanels) {
+        try {
+            if (panel && !panel.disposed) {
+                panel.dispose();
+            }
+        } catch (error) {
+            LOG(`Error disposing panel ${panelKey}: ${error.message}`);
+        }
+    }
+    activePanels.clear();
+    
     if (outputChannel !== undefined) {
         outputChannel.dispose();
     }
@@ -209,6 +225,44 @@ function getAttribute(taskObject, taskInfo, key, isRunning) {
         }
         return settings[key];
     }
+}
+
+function getTaskGroup(taskInfo) {
+    if (isObject(taskInfo.options) && isObject(taskInfo.options.statusbar)) {
+        return taskInfo.options.statusbar.group;
+    }
+    return undefined;
+}
+
+function parseGroupHierarchy(groupString) {
+    if (!groupString || typeof groupString !== 'string') {
+        return null;
+    }
+    
+    // Split by forward slash and clean up each part
+    const parts = groupString.split('/').map(part => part.trim()).filter(part => part.length > 0);
+    
+    if (parts.length === 0) {
+        return null;
+    }
+    
+    return {
+        fullPath: groupString,
+        parts: parts,
+        depth: parts.length,
+        parentPath: parts.length > 1 ? parts.slice(0, -1).join('/') : null,
+        leafName: parts[parts.length - 1]
+    };
+}
+
+function getGroupDisplayName(groupString) {
+    const hierarchy = parseGroupHierarchy(groupString);
+    return hierarchy ? hierarchy.leafName : groupString;
+}
+
+function getGroupFullPath(groupString) {
+    const hierarchy = parseGroupHierarchy(groupString);
+    return hierarchy ? hierarchy.fullPath : groupString;
 }
 
 function computeTaskExecutionId(taskInfo, type) {
@@ -363,6 +417,17 @@ function convertTooltip(tooltip) {
     }
 }
 
+function createMasterTasksStatusBar() {
+    return {
+        text: "Tasks",
+        tooltip: convertTooltip("Show all tasks organized by groups"),
+        color: undefined,
+        backgroundColor: undefined,
+        filePattern: undefined,
+        command: ShowAllTasksCommand,
+        isMaster: true
+    };
+}
 function createSelectStatusBar() {
     const settings = vscode.workspace.getConfiguration("tasks.statusbar.select");
     return {
@@ -373,6 +438,138 @@ function createSelectStatusBar() {
         filePattern: undefined,
         command: SelectTaskCommand
     };
+}
+
+function buildGroupTree(memoryStatusBarArray) {
+    const groupedTasks = [];
+    const ungroupedTasks = [];
+    
+    // Separate grouped and ungrouped tasks
+    for (const statusBarItem of memoryStatusBarArray) {
+        if (statusBarItem.group) {
+            groupedTasks.push(statusBarItem);
+        } else {
+            ungroupedTasks.push(statusBarItem);
+        }
+    }
+    
+    if (groupedTasks.length === 0) {
+        return ungroupedTasks;
+    }
+    
+    // Build tree structure
+    const tree = new Map();
+    
+    // First pass: collect all tasks by their root groups
+    for (const task of groupedTasks) {
+        const hierarchy = parseGroupHierarchy(task.group);
+        if (hierarchy) {
+            const rootGroup = hierarchy.parts[0];
+            if (!tree.has(rootGroup)) {
+                tree.set(rootGroup, {
+                    name: rootGroup,
+                    tasks: [],
+                    subgroups: new Map()
+                });
+            }
+            tree.get(rootGroup).tasks.push(task);
+        }
+    }
+    
+    // Build the hierarchical tree for each root group
+    for (const [rootName, rootGroup] of tree) {
+        buildSubgroupTree(rootGroup, rootGroup.tasks);
+    }
+    
+    const result = [];
+    
+    // Add ungrouped tasks first
+    result.push(...ungroupedTasks);
+    
+    // Process each root group
+    for (const [rootName, rootGroup] of tree) {
+        // Check if group has only one task
+        if (rootGroup.tasks.length === 1) {
+            // Show the individual task instead of a group button
+            const singleTask = rootGroup.tasks[0];
+            result.push({
+                text: singleTask.text,
+                tooltip: singleTask.tooltip,
+                color: singleTask.color,
+                backgroundColor: singleTask.backgroundColor,
+                filePattern: singleTask.filePattern,
+                isGroup: false, // Mark as individual task
+                command: singleTask.command // Use the task's command directly
+            });
+        } else {
+            // Create a group button for multiple tasks
+            result.push({
+                text: rootName,
+                tooltip: convertTooltip(`Group: ${rootName} (${rootGroup.tasks.length} tasks)`),
+                color: rootGroup.tasks[0]?.color,
+                backgroundColor: rootGroup.tasks[0]?.backgroundColor,
+                filePattern: rootGroup.tasks[0]?.filePattern,
+                isGroup: true,
+                isHierarchical: true,
+                groupPath: rootName,
+                groupTree: rootGroup,
+                groupTasks: rootGroup.tasks,
+                command: {
+                    command: ShowGroupTasksCommand,
+                    arguments: [rootGroup.tasks, rootGroup]
+                }
+            });
+        }
+    }
+    
+    return result;
+}
+
+function buildSubgroupTree(parentGroup, tasks) {
+    // Group tasks by their next level path segment relative to parent
+    const subgroupMap = new Map();
+    const directTasks = [];
+    
+    for (const task of tasks) {
+        const hierarchy = parseGroupHierarchy(task.group);
+        if (hierarchy && hierarchy.parts.length > 1) {
+            // Find the current depth based on parent group name
+            const parentDepth = parentGroup.name.split('/').length;
+            if (hierarchy.parts.length > parentDepth) {
+                // Has deeper subgroups
+                const nextLevel = hierarchy.parts[parentDepth];
+                if (!subgroupMap.has(nextLevel)) {
+                    subgroupMap.set(nextLevel, []);
+                }
+                subgroupMap.get(nextLevel).push(task);
+            }
+        } else {
+            // Direct task at this level
+            directTasks.push(task);
+        }
+    }
+    
+    // Build subgroup tree recursively
+    for (const [subgroupName, subgroupTasks] of subgroupMap) {
+        const fullSubgroupPath = parentGroup.name === subgroupName ? subgroupName : `${parentGroup.name}/${subgroupName}`;
+        const subgroup = {
+            name: fullSubgroupPath,
+            tasks: subgroupTasks,
+            subgroups: new Map()
+        };
+        
+        parentGroup.subgroups.set(subgroupName, subgroup);
+        
+        // Recursively build deeper levels
+        buildSubgroupTree(subgroup, subgroupTasks);
+    }
+}
+function groupTasks(memoryStatusBarArray) {
+    // Use the new hierarchical tree building approach
+    LOG(`groupTasks: Processing ${memoryStatusBarArray.length} tasks`);
+    const result = buildGroupTree(memoryStatusBarArray);
+    LOG(`groupTasks: Returning ${result.length} items`);
+    return result;
 }
 
 function syncStatusBar(memoryStatusBarArray) {
@@ -396,6 +593,9 @@ function syncStatusBar(memoryStatusBarArray) {
         to.backgroundColor = from.backgroundColor;
         to.filePattern = from.filePattern;
         to.command = from.command;
+        to.isGroup = from.isGroup || false; // Default to false if not specified
+        to.groupTasks = from.groupTasks;
+        to.isMaster = from.isMaster || false; // Default to false if not specified
     }
 }
 
@@ -430,12 +630,15 @@ function matchTasksInScope(memoryStatusBarArray, tasks, runningTasks, config) {
         const color = getAttribute(taskObject, taskInfo, "color", isRunning);
         const backgroundColor = getAttribute(taskObject, taskInfo, "backgroundColor", isRunning);
         const filePattern = getAttribute(taskObject, taskInfo, "filePattern");
+        const group = getTaskGroup(taskInfo);
+        
         memoryStatusBarArray.push({
             text: label,
             tooltip: convertTooltip(detail),
             color: convertColor(color),
             backgroundColor: backgroundColor ? new vscode.ThemeColor(backgroundColor) : undefined,
             filePattern: filePattern,
+            group: group,
             command: {
                 command: RunTaskCommand,
                 arguments: [taskObject]
@@ -487,13 +690,19 @@ function loadTasks() {
         tasks = tasks.filter(task => task.source === "Workspace");
         let memoryStatusBarArray = matchAllTasks(tasks);
         if (memoryStatusBarArray.length > 0) {
+            // Apply grouping logic
+            memoryStatusBarArray = groupTasks(memoryStatusBarArray);
+            // Add master tasks button at the beginning (leftmost position)
+            memoryStatusBarArray.unshift(createMasterTasksStatusBar());
             memoryStatusBarArray.push(createSelectStatusBar());
             syncStatusBar(memoryStatusBarArray);
             openUpdateStatusBar();
         }
         else {
-            cleanStatusBar();
-            closeUpdateStatusBar();
+            // Even if no tasks, show the master tasks button
+            const masterOnly = [createMasterTasksStatusBar()];
+            syncStatusBar(masterOnly);
+            openUpdateStatusBar();
         }
     });
 }
@@ -537,14 +746,33 @@ function refreshTask(task) {
         if (!statusBar.command.arguments) {
             return false;
         }
+        if (statusBar.isGroup) {
+            // Check if task is in group
+            return statusBar.groupTasks && statusBar.groupTasks.some(groupTask => 
+                groupTask.command.arguments[0]._id === task._id
+            );
+        }
         return statusBar.command.arguments[0]._id === task._id;
     });
     if (found) {
         const statusBar = memoryStatusBarArray[0];
-        found.text = statusBar.text;
-        found.tooltip = statusBar.tooltip;
-        found.color = statusBar.color;
-        found.backgroundColor = statusBar.backgroundColor;
+        if (found.isGroup && found.groupTasks) {
+            // Update task within group
+            const taskInGroup = found.groupTasks.find(groupTask => 
+                groupTask.command.arguments[0]._id === task._id
+            );
+            if (taskInGroup) {
+                taskInGroup.text = statusBar.text;
+                taskInGroup.tooltip = statusBar.tooltip;
+                taskInGroup.color = statusBar.color;
+                taskInGroup.backgroundColor = statusBar.backgroundColor;
+            }
+        } else {
+            found.text = statusBar.text;
+            found.tooltip = statusBar.tooltip;
+            found.color = statusBar.color;
+            found.backgroundColor = statusBar.backgroundColor;
+        }
     }
 }
 
@@ -552,6 +780,538 @@ function runTask(task) {
     vscode.tasks.executeTask(task).catch((err) => {
         vscode.window.showWarningMessage(err.message).then(_ => undefined);
     });
+}
+
+function showAllTasks() {
+    // Fetch all tasks to build the complete tree
+    vscode.tasks.fetchTasks().then((allTasks) => {
+        const workspaceTasks = allTasks.filter(task => task.source === "Workspace");
+        const allTaskItems = matchAllTasks(workspaceTasks);
+        
+        // Build complete hierarchical tree
+        const masterTree = buildMasterTaskTree(allTaskItems);
+        
+        // Show in webview panel
+        showMasterTasksPanel(masterTree);
+    });
+}
+
+function buildMasterTaskTree(allTaskItems) {
+    const tree = {
+        name: "All Tasks",
+        groups: new Map(),
+        ungroupedTasks: []
+    };
+    
+    // Separate grouped and ungrouped tasks
+    for (const task of allTaskItems) {
+        if (task.group) {
+            const hierarchy = parseGroupHierarchy(task.group);
+            if (hierarchy) {
+                addTaskToTree(tree, hierarchy, task);
+            }
+        } else {
+            tree.ungroupedTasks.push(task);
+        }
+    }
+    
+    return tree;
+}
+
+function addTaskToTree(tree, hierarchy, task) {
+    let currentLevel = tree.groups;
+    let currentPath = "";
+    
+    // Navigate/create the tree structure
+    for (let i = 0; i < hierarchy.parts.length; i++) {
+        const part = hierarchy.parts[i];
+        currentPath = currentPath ? `${currentPath}/${part}` : part;
+        
+        if (!currentLevel.has(part)) {
+            currentLevel.set(part, {
+                name: part,
+                fullPath: currentPath,
+                tasks: [],
+                subgroups: new Map()
+            });
+        }
+        
+        const group = currentLevel.get(part);
+        
+        // If this is the final level, add the task
+        if (i === hierarchy.parts.length - 1) {
+            group.tasks.push(task);
+        }
+        
+        // Move to next level
+        currentLevel = group.subgroups;
+    }
+}
+
+// Helper Functions for Panel Management
+function createOrFocusPanel(panelKey, title, createPanelFn) {
+    if (activePanels.has(panelKey)) {
+        const existingPanel = activePanels.get(panelKey);
+        if (existingPanel && !existingPanel.disposed) {
+            existingPanel.reveal(vscode.ViewColumn.Active, false);
+            LOG(`Focusing existing panel: ${title}`);
+            return null; // Return null to indicate panel already exists
+        } else {
+            activePanels.delete(panelKey);
+        }
+    }
+    
+    // Create new panel
+    const panel = createPanelFn();
+    activePanels.set(panelKey, panel);
+    
+    // Set up common disposal handling
+    panel.onDidDispose(() => {
+        activePanels.delete(panelKey);
+    });
+    
+    return panel;
+}
+
+function createWebviewPanel(id, title, options = {}) {
+    const defaultOptions = {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: []
+    };
+    
+    return vscode.window.createWebviewPanel(
+        id,
+        title,
+        {
+            viewColumn: vscode.ViewColumn.Active,
+            preserveFocus: false
+        },
+        { ...defaultOptions, ...options }
+    );
+}
+
+function setupPanelMessageHandling(panel, panelKey, messageHandlers) {
+    panel.webview.onDidReceiveMessage(message => {
+        if (message.command === 'close') {
+            activePanels.delete(panelKey);
+            panel.dispose();
+            return;
+        }
+        
+        const handler = messageHandlers[message.command];
+        if (handler) {
+            handler(message);
+        }
+    });
+}
+
+function autoFocusPanel(panel, timeout = 100) {
+    setTimeout(() => {
+        if (panel.visible) {
+            panel.reveal(vscode.ViewColumn.Active, true);
+        }
+    }, timeout);
+}
+
+function generateTaskButton(task, index, indentLevel = 0) {
+    const label = task.text.replace(/\$\([^)]+\)\s*/, '');
+    const tooltip = task.tooltip ? task.tooltip.value || '' : '';
+    const indent = indentLevel * 20;
+    
+    return `
+        <button class="task-button" onclick="executeTask(${index})" 
+                title="${tooltip}" style="margin-left: ${indent}px;">
+            <span class="task-icon">•</span>
+            <span class="task-label">${label}</span>
+        </button>
+    `;
+}
+
+function generateGroupButton(groupName, groupPath, taskCount, level = 0) {
+    const indent = level * 20;
+    const groupId = `group-${groupPath.replace(/[^a-zA-Z0-9]/g, '-')}-${level}`;
+    
+    return `
+        <div class="group-container" style="margin-left: ${indent}px;">
+            <button class="group-header" onclick="toggleGroup('${groupId}')" 
+                    title="${groupPath}">
+                <span class="expand-icon" id="icon-${groupId}">▶</span>
+                <span class="group-name">${groupName}/</span>
+                <span class="task-count">(${taskCount})</span>
+            </button>
+            <div class="group-content" id="content-${groupId}" style="display: none;">
+    `;
+}
+
+
+function getCommonJavaScript(dataArray, dataVariableName = 'allTasks') {
+    return `
+        const vscode = acquireVsCodeApi();
+        const ${dataVariableName} = ${JSON.stringify(dataArray)};
+        
+        function executeTask(index) {
+            if (index >= 0 && index < ${dataVariableName}.length) {
+                vscode.postMessage({
+                    command: 'executeTask',
+                    taskIndex: index
+                });
+            }
+        }
+        
+        function toggleGroup(id) {
+            const content = document.getElementById('content-' + id);
+            const icon = document.getElementById('icon-' + id);
+            
+            if (content && icon) {
+                if (content.style.display === 'none') {
+                    content.style.display = 'block';
+                    icon.classList.add('expanded');
+                } else {
+                    content.style.display = 'none';
+                    icon.classList.remove('expanded');
+                }
+            }
+        }
+        
+        window.addEventListener('load', () => {
+            document.body.focus();
+        });
+        
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                vscode.postMessage({ command: 'close' });
+            }
+        });
+    `;
+}
+
+function showMasterTasksPanel(masterTree) {
+    const panelKey = 'masterTasksPanel';
+    
+    const panel = createOrFocusPanel(panelKey, 'All Tasks', () => 
+        createWebviewPanel('masterTasksPanel', 'All Tasks')
+    );
+    
+    if (!panel) return; // Panel already exists and was focused
+
+    // Collect all tasks for execution mapping
+    const allTasks = [];
+    function collectAllTasks(groups) {
+        for (const [groupName, group] of groups) {
+            allTasks.push(...group.tasks);
+            collectAllTasks(group.subgroups);
+        }
+    }
+    collectAllTasks(masterTree.groups);
+    allTasks.push(...masterTree.ungroupedTasks);
+
+    // Generate tree HTML
+    function generateMasterTreeHTML(groups, level = 0) {
+        let html = '';
+        
+        for (const [groupName, group] of groups) {
+            const hasSubgroups = group.subgroups.size > 0;
+            const hasDirectTasks = group.tasks.length > 0;
+            
+            if (hasSubgroups || hasDirectTasks) {
+                const taskCount = group.tasks.length + countNestedTasks(group.subgroups);
+                html += generateGroupButton(groupName, group.fullPath, taskCount, level);
+                
+                // Direct tasks in this group
+                for (const task of group.tasks) {
+                    const taskIndex = allTasks.indexOf(task);
+                    html += generateTaskButton(task, taskIndex, level + 1);
+                }
+                
+                // Recursive subgroups
+                html += generateMasterTreeHTML(group.subgroups, level + 1);
+                html += '</div></div>';
+            }
+        }
+        
+        return html;
+    }
+    
+    function countNestedTasks(groups) {
+        let count = 0;
+        for (const [_, group] of groups) {
+            count += group.tasks.length;
+            count += countNestedTasks(group.subgroups);
+        }
+        return count;
+    }
+
+    // Generate ungrouped tasks HTML
+    let ungroupedHTML = '';
+    if (masterTree.ungroupedTasks.length > 0) {
+        ungroupedHTML = '<div class="ungrouped-section"><div class="section-header">Ungrouped Tasks:</div>';
+        for (const task of masterTree.ungroupedTasks) {
+            const taskIndex = allTasks.indexOf(task);
+            ungroupedHTML += generateTaskButton(task, taskIndex);
+        }
+        ungroupedHTML += '</div>';
+    }
+
+    panel.webview.html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            ${panelCSS}
+        </head>
+        <body>
+            <div class="header">All Tasks</div>
+            ${generateMasterTreeHTML(masterTree.groups)}
+            ${ungroupedHTML}
+            
+            <script>
+                ${getCommonJavaScript(allTasks)}
+                
+                // Auto-expand first level on load
+                window.addEventListener('load', () => {
+                    const firstLevelGroups = document.querySelectorAll('[id^="content-group-"][id$="-0"]');
+                    firstLevelGroups.forEach(group => {
+                        const id = group.id.replace('content-', '');
+                        toggleGroup(id);
+                    });
+                });
+            </script>
+        </body>
+        </html>
+    `;
+
+    setupPanelMessageHandling(panel, panelKey, {
+        executeTask: (message) => {
+            const taskIndex = message.taskIndex;
+            if (taskIndex >= 0 && taskIndex < allTasks.length) {
+                const task = allTasks[taskIndex].command.arguments[0];
+                runTask(task);
+            }
+        }
+    });
+
+    autoFocusPanel(panel);
+}
+
+function showSelectTasks(items) {
+    const panelKey = 'taskSelectDropdown';
+    
+    const panel = createOrFocusPanel(panelKey, 'Select Tasks', () => 
+        createWebviewPanel('taskSelectDropdown', 'Select Tasks')
+    );
+    
+    if (!panel) return;
+
+    // Generate HTML for all tasks including groups
+    const taskButtons = items.map((item, index) => {
+        const label = item.text.replace(/\$\([^)]+\)\s*/, '');
+        const tooltip = item.tooltip ? item.tooltip.value || '' : '';
+        const isGroup = item.isGroup;
+        
+        return `
+            <button class="task-button ${isGroup ? 'group-button' : ''}" 
+                    onclick="${isGroup ? `showGroup(${index})` : `executeTask(${index})`}" 
+                    title="${tooltip}">
+                <span class="task-label">${label}${isGroup ? ' ▼' : ''}</span>
+                ${tooltip ? `<span class="task-description">${tooltip}</span>` : ''}
+            </button>
+        `;
+    }).join('');
+
+    panel.webview.html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            ${panelCSS}
+        </head>
+        <body>
+            <div class="header">Select task to execute:</div>
+            ${taskButtons}
+            <script>
+                ${getCommonJavaScript(items)}
+                
+                function showGroup(index) {
+                    vscode.postMessage({
+                        command: 'showGroup',
+                        groupIndex: index
+                    });
+                }
+            </script>
+        </body>
+        </html>
+    `;
+
+    setupPanelMessageHandling(panel, panelKey, {
+        executeTask: (message) => {
+            const taskIndex = message.taskIndex;
+            if (taskIndex >= 0 && taskIndex < items.length && !items[taskIndex].isGroup) {
+                const task = items[taskIndex].command.arguments[0];
+                runTask(task);
+            }
+        },
+        showGroup: (message) => {
+            const groupIndex = message.groupIndex;
+            if (groupIndex >= 0 && groupIndex < items.length && items[groupIndex].isGroup) {
+                if (items[groupIndex].groupTasks.length === 1) {
+                    const task = items[groupIndex].groupTasks[0].command.arguments[0];
+                    runTask(task);
+                    activePanels.delete(panelKey);
+                    panel.dispose();
+                } else {
+                    activePanels.delete(panelKey);
+                    panel.dispose();
+                    const groupName = items[groupIndex].text;
+                    showGroupTasks(items[groupIndex].groupTasks, groupName);
+                }
+            }
+        }
+    });
+
+    autoFocusPanel(panel);
+}
+
+function showHierarchicalGroupTasks(groupTree) {
+    const panelKey = `hierarchicalTaskGroup-${groupTree.name.replace(/[^a-zA-Z0-9]/g, '-')}`;
+    
+    const panel = createOrFocusPanel(panelKey, groupTree.name, () => 
+        createWebviewPanel('hierarchicalTaskGroup', groupTree.name)
+    );
+    
+    if (!panel) return;
+
+    // Generate HTML for hierarchical view
+    function generateTreeHTML(group, level = 0) {
+        let html = '';
+        
+        // Add direct tasks at this level
+        const directTasks = group.tasks.filter(task => {
+            const hierarchy = parseGroupHierarchy(task.group);
+            return hierarchy && hierarchy.parts.length === level + 1;
+        });
+        
+        for (const task of directTasks) {
+            const taskIndex = group.tasks.indexOf(task);
+            html += generateTaskButton(task, taskIndex, level);
+        }
+        
+        // Add subgroups
+        for (const [subgroupName, subgroup] of group.subgroups) {
+            html += `
+                <div class="subgroup" style="margin-left: ${level * 20}px;">
+                    <button class="subgroup-header" onclick="toggleSubgroup('${subgroupName}-${level}')" 
+                            title="Expand/Collapse ${subgroupName}">
+                        <span class="expand-icon" id="icon-${subgroupName}-${level}">▶</span>
+                        <span class="subgroup-name">${subgroupName}/</span>
+                    </button>
+                    <div class="subgroup-content" id="content-${subgroupName}-${level}" style="display: none;">
+                        ${generateTreeHTML(subgroup, level + 1)}
+                    </div>
+                </div>
+            `;
+        }
+        
+        return html;
+    }
+
+    panel.webview.html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            ${panelCSS}
+        </head>
+        <body>
+            <div class="header">${groupTree.name}:</div>
+            ${generateTreeHTML(groupTree)}
+            
+            <script>
+                ${getCommonJavaScript(groupTree.tasks, 'groupTasks')}
+                
+                function toggleSubgroup(id) {
+                    const content = document.getElementById('content-' + id);
+                    const icon = document.getElementById('icon-' + id);
+                    
+                    if (content.style.display === 'none') {
+                        content.style.display = 'block';
+                        icon.classList.add('expanded');
+                    } else {
+                        content.style.display = 'none';
+                        icon.classList.remove('expanded');
+                    }
+                }
+            </script>
+        </body>
+        </html>
+    `;
+
+    setupPanelMessageHandling(panel, panelKey, {
+        executeTask: (message) => {
+            const taskIndex = message.taskIndex;
+            if (taskIndex >= 0 && taskIndex < groupTree.tasks.length) {
+                const task = groupTree.tasks[taskIndex].command.arguments[0];
+                runTask(task);
+            }
+        }
+    });
+
+    autoFocusPanel(panel);
+}
+
+function showGroupTasks(groupTasks, groupName = 'Tasks') {
+
+    // const panelKey = `taskGroupDropdown-${groupName}`;
+    const panelKey = `taskGroupDropdown-${groupName.replace(/[^a-zA-Z0-9]/g, '-')}`;
+    
+    const panel = createOrFocusPanel(panelKey, groupName, () => 
+        createWebviewPanel('taskGroupDropdown', groupName)
+    );
+    
+    if (!panel) return;
+
+    // Generate HTML for the dropdown
+    const taskButtons = groupTasks.map((task, index) => {
+        const label = task.text.replace(/\$\([^)]+\)\s*/, '');
+        const tooltip = task.tooltip ? task.tooltip.value || '' : '';
+        return `
+            <button class="task-button" onclick="executeTask(${index})" title="${tooltip}">
+                <span class="task-label">${label}</span>
+                ${tooltip ? `<span class="task-description">${tooltip}</span>` : ''}
+            </button>
+        `;
+    }).join('');
+
+    panel.webview.html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            ${panelCSS}
+        </head>
+        <body>
+            <div class="header">Select task to execute:</div>
+            ${taskButtons}
+            <script>${getCommonJavaScript(groupTasks, 'groupTasks')}</script>
+        </body>
+        </html>
+    `;
+
+    setupPanelMessageHandling(panel, panelKey, {
+        executeTask: (message) => {
+            const taskIndex = message.taskIndex;
+            if (taskIndex >= 0 && taskIndex < groupTasks.length) {
+                const task = groupTasks[taskIndex].command.arguments[0];
+                runTask(task);
+            }
+        }
+    });
+
+    autoFocusPanel(panel);
 }
 
 function activate(context) {
@@ -576,13 +1336,73 @@ function activate(context) {
                     break;
             }
         }),
-        vscode.commands.registerCommand(SelectTaskCommand, () => {
-            vscode.window.showQuickPick(selectList, { placeHolder: "Select task to execute" }).then(value => {
-                if (value !== undefined) {
-                    runTask(value.task);
-                }
-            })
+        vscode.commands.registerCommand(ShowAllTasksCommand, () => {
+            showAllTasks();
         }),
+        vscode.commands.registerCommand(SelectTaskCommand, () => {
+            if (selectList.some(item => Array.isArray(item.task))) {
+                // If there are grouped tasks in select list, show them in webview too
+                const webviewItems = selectList.map(item => {
+                    if (Array.isArray(item.task)) {
+                        // Check if group has only one task
+                        if (item.task.length === 1) {
+                            // Convert single-task group to regular task item
+                            return {
+                                text: item.label,
+                                tooltip: { value: item.description },
+                                command: { arguments: [item.task[0]] },
+                                isGroup: false
+                            };
+                        } else {
+                            return {
+                                text: item.label,
+                                tooltip: { value: item.description },
+                                command: { arguments: [null] },
+                                isGroup: true,
+                                groupTasks: item.task
+                            };
+                        }
+                    } else {
+                        return {
+                            text: item.label,
+                            tooltip: { value: item.description },
+                            command: { arguments: [item.task] }
+                        };
+                    }
+                });
+                showSelectTasks(webviewItems);
+            } else {
+                vscode.window.showQuickPick(selectList, { placeHolder: "Select task to execute" }).then(value => {
+                    if (value !== undefined) {
+                        runTask(value.task);
+                    }
+                });
+            }
+        }),
+
+        vscode.commands.registerCommand(ShowGroupTasksCommand, (groupTasks, groupTree = null) => {
+            // Check if group has only one task - if so, execute it directly
+            if (groupTasks.length === 1) {
+                LOG(`Single task in group, executing directly: ${groupTasks[0].text}`);
+                runTask(groupTasks[0].command.arguments[0]);
+                return;
+            }
+            
+            // Extract group name from the first task in the group
+            let groupName = 'Tasks';
+            if (groupTasks.length > 0 && groupTasks[0].group) {
+                const groupPath = groupTasks[0].group;
+                groupName = getGroupDisplayName(groupPath);
+            }
+            
+            // If we have a tree structure, show hierarchical view
+            if (groupTree) {
+                showHierarchicalGroupTasks(groupTree);
+            } else {
+                showGroupTasks(groupTasks, groupName);
+            }
+        }),
+
         vscode.workspace.onDidChangeConfiguration(loadTasksWait),
         vscode.workspace.onDidChangeWorkspaceFolders(loadTasksWait),
         vscode.tasks.onDidStartTask((e) => {
@@ -597,3 +1417,150 @@ function activate(context) {
 
 exports.activate = activate;
 exports.deactivate = deactivate;
+
+const panelCSS = `
+  <style>
+    body {
+      margin: 0;
+      padding: 12px;
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      background: var(--vscode-sideBar-background);
+      color: var(--vscode-foreground);
+      min-width: 350px;
+      max-width: 600px;
+      max-height: 80vh;
+      overflow-y: auto;
+    }
+    .header {
+      padding: 8px 12px 12px 12px;
+      border-bottom: 1px solid var(--vscode-panel-border);
+      margin-bottom: 12px;
+      font-size: 1.1em;
+      font-weight: 600;
+      color: var(--vscode-panelTitle-activeForeground);
+    }
+    .group-header,
+    .task-button {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      padding: 6px 8px;
+      margin: 1px 0;
+      background: transparent;
+      border: none;
+      color: var(--vscode-foreground);
+      cursor: pointer;
+      text-align: left;
+      border-radius: 3px;
+      transition: background 0.1s;
+    }
+    .group-header:hover,
+    .task-button:hover {
+      background: var(--vscode-list-hoverBackground);
+    }
+    .task-button:active {
+      background: var(--vscode-list-activeSelectionBackground);
+    }
+    .expand-icon {
+      display: inline-block;
+      width: 16px;
+      margin-right: 4px;
+      transition: transform 0.2s;
+      font-size: 12px;
+    }
+    .expand-icon.expanded {
+      transform: rotate(90deg);
+    }
+    .group-name {
+      color: var(--vscode-symbolIcon-folderForeground);
+      flex-grow: 1;
+    }
+    .task-count {
+      font-size: 0.9em;
+      color: var(--vscode-descriptionForeground);
+      margin-left: 8px;
+    }
+    .task-icon {
+    //   display: inline-block;
+      width: 16px;
+      margin-right: 8px;
+      color: var(--vscode-descriptionForeground);
+      font-size: 14px;
+    }
+    .task-label {
+      flex-grow: 1;
+    }
+    .group-content {
+      overflow: hidden;
+    }
+    .section-header {
+      font-weight: 500;
+      color: var(--vscode-panelTitle-activeForeground);
+      margin: 12px 0 6px 0;
+      padding: 4px 8px;
+      border-bottom: 1px solid var(--vscode-panel-border);
+    }
+    .ungrouped-section {
+      margin-top: 16px;
+    }
+
+    // .task-description {
+    //     font-size: 0.9em;
+    //     color: var(--vscode-descriptionForeground);
+    //     margin-top: 2px;
+    // }
+    // .task-button:hover {
+    //     background: var(--vscode-list-hoverBackground);
+    // }
+    // .subgroup-header {
+    //     display: block;
+    //     width: calc(100% - 20px);
+    //     padding: 4px 12px;
+    //     margin: 2px 0;
+    //     background: transparent;
+    //     border: none;
+    //     color: var(--vscode-foreground);
+    //     cursor: pointer;
+    //     text-align: left;
+    //     border-radius: 2px;
+    //     font-weight: 500;
+    // }
+    // .subgroup-header:hover {
+    //     background: var(--vscode-list-hoverBackground);
+    // }
+    // .subgroup-name {
+    //     color: var(--vscode-symbolIcon-folderForeground);
+    // }
+    // .subgroup-content {
+    //     overflow: hidden;
+    //     transition: all 0.2s ease;
+    // }
+
+
+    .subgroup-header {
+        display: block;
+        width: calc(100% - 20px);
+        padding: 4px 12px;
+        margin: 2px 0;
+        background: transparent;
+        border: none;
+        color: var(--vscode-foreground);
+        cursor: pointer;
+        text-align: left;
+        border-radius: 2px;
+        font-weight: 500;
+    }
+    .subgroup-header:hover {
+        background: var(--vscode-list-hoverBackground);
+    }
+    .subgroup-name {
+        color: var(--vscode-symbolIcon-folderForeground);
+    }
+    .subgroup-content {
+        overflow: hidden;
+        transition: all 0.2s ease;
+    }
+
+</style>
+`;

--- a/test-workspace/.vscode/tasks.json
+++ b/test-workspace/.vscode/tasks.json
@@ -1,17 +1,171 @@
 {
   "version": "2.0.0",
   "tasks": [
+
+    // a simple tasked not using plugin specific functionality
     {
-      "label": "Say Hello",
+			"label": "Simple",
+			"type": "shell",
+			"command": "echo",
+			"args": ["'simple was pressed'"],
+      // omitting group (is an ungrouped task)
+		},
+
+    {
+      "label": "a", // value does not matter when options/label is given. Must not be ""
       "type": "shell",
-      "command": "echo Hello, World!",
+      "command": "echo 'Custom Item 🔥 was pressed'",
       "options": {
         "statusbar": {
-          "label": "👋 Hello",
-          "color": "#00ff00"
-        }
+          "label": "$(refresh) Custom Item 🔥",
+          "color": "#ff7b00",
+          "detail": "tooltip for statusbar",
+          // omitting group (is an ungrouped task)
+        },
       },
-      "problemMatcher": []
+    },
+
+    {
+      "label": "Empty Group",
+      "type": "shell",
+      "command": "echo 'Empty Group was pressed'",
+      "options": {
+        "statusbar": {
+          "group": "", // empty does not count as a group (is ungrouped task)
+        },
+      },
+    },
+
+    // hidden tasks
+    {
+      "label": "",
+      "type": "shell",
+      "command": "echo 'Hidden Item was pressed'",
+      "options": {
+        "statusbar": {
+          "hide" : true, // hidden items are not displayed in StatusBar
+        },
+      },
+    },
+    {
+      "label": "Hidden Item grouped",
+      "type": "shell",
+      "command": "echo 'Hidden Item grouped was pressed'",
+      "options": {
+        "statusbar": {
+          "hide" : true,
+          "group": "👋 hello", // hidden items are also not displayed in group windows
+        },
+      },
+    },
+
+    // 2 member group
+    {
+      "label": "Hello 1", // value does not matter when options/label is given. Must not be ""
+      "type": "shell",
+      "command": "echo '👋 Hello 1 was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "👋 Hello 1",
+          "color": "#fbff00", // the first item of a group can style the color of the group button
+          "group": "👋 hello group",
+        },
+      },
+    },
+    {
+      "label": "Hello 2", // value does not matter when options/label is given. Must not be ""
+      "type": "shell",
+      "command": "echo '👋 Hello 2 was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "👋 Hello 2",
+          "color": "#00aeff", // ignored, since not first member of group
+          "group": "👋 hello group",
+        },
+      },
+    },
+
+    // subgroups
+    // are divided with `/`
+    {
+      "label": "Build Frontend",
+      "type": "shell",
+      "command": "echo 'Build Frontend was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "🏗️ Build Frontend",
+          "group": "subgroup/frontend", // displayed as `subgroup` in StatusBar
+        }
+      }
+    },
+    {
+      "label": "Build Frontend",
+      "type": "shell",
+      "command": "echo 'Build Frontend was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "🏗️ Build Frontend",
+          "group": "//subgroup///frontend", // displayed as `subgroup` in StatusBar
+        }
+      }
+    },
+    {
+      "label": "Build React App",
+      "command": "echo 'Build React App was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "$(refresh) Build React",
+          "group": "subgroup/frontend/react", // displayed as `subgroup` in StatusBar
+					"detail": "Regenerates all templ files",
+        }
+      }
+    },
+    {
+      "label": "Build Vue App",
+      "command": "echo 'Build Vue App was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "Build Vue",
+          "group": "subgroup/frontend/vue" // displayed as `subgroup` in StatusBar
+        }
+      }
+    },
+    {
+      "label": "Build API",
+      "command": "echo 'Build API was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "Build API",
+          "group": "subgroup/backend/api" // displayed as `subgroup` in StatusBar
+        }
+      }
+    },
+
+    // single member group are displayed as task buttun in StatusBar (do not get a window)
+    {
+      "label": "Single Member Group",
+      "type": "shell",
+      "command": "echo 'Single Member Group was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "Single Member Group",
+          "color": "#00ff00",
+          "group": "Single Member Group",
+        },
+      },
+    },
+    // single member group as subgroup
+    {
+      "label": "Single Member SubGroup",
+      "type": "shell",
+      "command": "echo 'Single Member SubGroup was pressed'",
+      "options": {
+        "statusbar": {
+          "label": "Single Member SubGroup",
+          "color": "#00ff00",
+          "group": "group/subgroup1/subgroup2"
+        }
+      }
     },
   ]
 }

--- a/test-workspace/.vscode/tasks.json
+++ b/test-workspace/.vscode/tasks.json
@@ -38,7 +38,7 @@
 
     // hidden tasks
     {
-      "label": "",
+      "label": "hidden",
       "type": "shell",
       "command": "echo 'Hidden Item was pressed'",
       "options": {

--- a/test-workspace/.vscode/tasks.json
+++ b/test-workspace/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Say Hello",
+      "type": "shell",
+      "command": "echo Hello, World!",
+      "options": {
+        "statusbar": {
+          "label": "👋 Hello",
+          "color": "#00ff00"
+        }
+      },
+      "problemMatcher": []
+    },
+  ]
+}

--- a/test-workspace/.vscode/tasks.json
+++ b/test-workspace/.vscode/tasks.json
@@ -116,7 +116,6 @@
         "statusbar": {
           "label": "$(refresh) Build React",
           "group": "subgroup/frontend/react", // displayed as `subgroup` in StatusBar
-					"detail": "Regenerates all templ files",
         }
       }
     },


### PR DESCRIPTION
allows to group tasks in groups and subgroups. this functionality is completly optional and does not conflict with previous functionality. see tasks.json for usage

demonstration:

[demo](https://github.com/user-attachments/assets/a5456155-2cf4-4059-b9c8-0aa6db75fead)


sidenote:
- this pr contains #56 to easily demonstrate the grouping functionality. should therefore be merged after it