### PR TITLE
move tasks to most right position

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -378,7 +378,7 @@ function createSelectStatusBar() {
 function syncStatusBar(memoryStatusBarArray) {
     const diff = memoryStatusBarArray.length - statusBarArray.length;
     for (let i = 0; i < diff; ++i) {
-        let statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
+        let statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
         statusBar.name = "Tasks";
         statusBarArray.push(statusBar);
     }


### PR DESCRIPTION
changes the position of tasks to the most right

I think this is more sensible since the size of tasks can vary depending on project. if another plugin added (exp for me its git graph), its position depends on the width of tasks, which is very annoying. 

